### PR TITLE
fix threedots font lock to only highlight at the beginning of line

### DIFF
--- a/robot-mode.el
+++ b/robot-mode.el
@@ -149,7 +149,7 @@ indenting a line. Otherwise move `point' always `back-to-indentation'."
 (defvar robot-mode-font-lock-keywords
   '(("^\\*.*" . font-lock-keyword-face)
     ("\\[\\sw+\\]" . font-lock-constant-face)
-    ("\\.\\.\\." . font-lock-constant-face)
+    ("^\\s-*\\(\\.\\.\\.\\)" . (1 font-lock-constant-face))
     ("[@$&%]{[^}]*}" . font-lock-variable-name-face)
     ("^\\(Library\\|Resource\\|\\(Suite\\|Task\\|Test\\) \\(Setup\\|Teardown\\|Template\\|Timeout\\)\\|Variables\\):?\\s-*\\(.*?\\)\\(\\s-\\{2,\\}\\|$\\)"
      (1 font-lock-preprocessor-face) (4 font-lock-constant-face append))


### PR DESCRIPTION
This PR will ensure that the three dots used to split lines and arguments is only highlighted when at the beginning of the line
Before:
![image](https://github.com/kopoli/robot-mode/assets/34922853/4a51b5b6-663c-4cca-bc0d-40cc35a7f756)

After:
![image](https://github.com/kopoli/robot-mode/assets/34922853/f6dc924d-fa74-4059-9f73-71ddf21509ca)
