### PR TITLE
Fix string font lock handled like programs in robot framework

### DIFF
--- a/robot-mode.el
+++ b/robot-mode.el
@@ -188,6 +188,8 @@ indenting a line. Otherwise move `point' always `back-to-indentation'."
   (with-syntax-table (make-syntax-table)
     (modify-syntax-entry ?# "<")
     (modify-syntax-entry ?\n ">")
+    (modify-syntax-entry ?\" ".")
+    (modify-syntax-entry ?\' ".")
     (syntax-table))
   "Syntax table for Robot mode.")
 


### PR DESCRIPTION
Robot Framework syntax doesn't support string (everything is a string)

Highlighting them is unnecessary and create font-lock problems. 
You can have a single `'` or `"` without matching pair in the same line.

Before:

<img width="523" height="347" alt="image" src="https://github.com/user-attachments/assets/2841dd24-74de-407e-8b66-f2fa4b6c5f20" />


After:

<img width="582" height="400" alt="image" src="https://github.com/user-attachments/assets/233a5ea4-4d01-45a5-b119-da43ceb276f7" />
